### PR TITLE
Opt out of mouse mode for Xbox UWAs

### DIFF
--- a/tvjs/src/DirectionalNavigation/directionalnavigation-1.0.0.0.js
+++ b/tvjs/src/DirectionalNavigation/directionalnavigation-1.0.0.0.js
@@ -922,4 +922,13 @@
             configurable: true
         });
     }
+
+    // The gamepadInputEmulation is a string property that exists in JavaScript UWAs and in WebViews in UWAs.
+    // It won't exist in Win8.1 style apps or browsers.
+    if (typeof window.navigator.gamepadInputEmulation === "string") {
+        // We want the gamepad to provide gamepad VK keyboard events rather than moving a
+        // mouse like cursor. Set to "keyboard", the gamepad will provide such keyboard events
+        // and provide input to the DOM navigator.getGamepads API.
+        window.navigator.gamepadInputEmulation = "keyboard";
+    }
 })();


### PR DESCRIPTION
Add the opt out of mouse mode to directionalnavigation.js. DirectionalNavigation.js relies on the gamepad producing keyboard events and on Xbox the default is to have the gamepad move a mouse-like cursor rather than produce keyboard events. 
