### PR TITLE
Blur WebView activeElement when focus exits.

### DIFF
--- a/tvjs/src/DirectionalNavigation/directionalnavigation-1.0.0.0.js
+++ b/tvjs/src/DirectionalNavigation/directionalnavigation-1.0.0.0.js
@@ -269,6 +269,7 @@
                     refRect = document.activeElement ? _toIRect(document.activeElement.getBoundingClientRect()) : _defaultRect();
                 }
                 if (top === window && typeof window.departFocus === "function") {
+                    document.activeElement.blur();
                     departFocus(direction, WebViewHelper.refRectToNavigateFocusRect(refRect));
                 }
                 else {


### PR DESCRIPTION
Currently, if you navigate inside and then out of WebView content there are multiple focused elements, one inside and one outside of the WebView. (See screenshot below.) This fix addresses that by calling blur on the active element in the WebView when focus departs the WebView.

![image](https://cloud.githubusercontent.com/assets/1725349/15948473/d04e1060-2e55-11e6-894e-599c0cca6f8b.png)
